### PR TITLE
fdbdir: fix upgrade by editing rpaths after install

### DIFF
--- a/Formula/fdbdir.rb
+++ b/Formula/fdbdir.rb
@@ -33,7 +33,7 @@ class Fdbdir < Formula
 
   def install
 
-bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
+    bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
     bin.install "fdbdir" if OS.mac? && Hardware::CPU.intel?
 
     # Ensure dyld can locate libfdb_c on macOS

--- a/Formula/fdbdir.rb
+++ b/Formula/fdbdir.rb
@@ -32,15 +32,23 @@ class Fdbdir < Formula
   end
 
   def install
-  bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
-    bin.install "fdbdir" if OS.mac? && Hardware::CPU.intel?
 
-    # Ensure dyld can locate libfdb_c on macOS
-    if OS.mac?
-      macho = MachO::MachOFile.new((bin/["fdbdir"]).to_s)
-      macho.rpaths << "/usr/local/lib" unless macho.rpaths.include?("/usr/local/lib")
-      macho.rpaths << "/opt/homebrew/lib" unless macho.rpaths.include?("/opt/homebrew/lib")
-      macho.write!
+      bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
+
+        bin.install "fdbdir" if OS.mac? && Hardware::CPU.intel?
+
+
+        # Ensure dyld can locate libfdb_c on macOS
+
+        if OS.mac?
+
+          macho = MachO::MachOFile.new((bin/["fdbdir"]).to_s)
+
+          macho.rpaths << "/usr/local/lib" unless macho.rpaths.include?("/usr/local/lib")
+
+          macho.rpaths << "/opt/homebrew/lib" unless macho.rpaths.include?("/opt/homebrew/lib")
+
+          macho.write!
     end
 
     bin.install "fdbdir" if OS.linux? && Hardware::CPU.intel?

--- a/Formula/fdbdir.rb
+++ b/Formula/fdbdir.rb
@@ -30,18 +30,19 @@ class Fdbdir < Formula
       end
     end
   end
-
   def install
+
+bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
+    bin.install "fdbdir" if OS.mac? && Hardware::CPU.intel?
+
     # Ensure dyld can locate libfdb_c on macOS
     if OS.mac?
-      macho = MachO::MachOFile.new((bin/"fdbdir").to_s)
+      macho = MachO::MachOFile.new((bin/["fdbdir"]).to_s)
       macho.rpaths << "/usr/local/lib" unless macho.rpaths.include?("/usr/local/lib")
       macho.rpaths << "/opt/homebrew/lib" unless macho.rpaths.include?("/opt/homebrew/lib")
       macho.write!
     end
 
-    bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
-    bin.install "fdbdir" if OS.mac? && Hardware::CPU.intel?
     bin.install "fdbdir" if OS.linux? && Hardware::CPU.intel?
 
     install_binary_aliases!

--- a/Formula/fdbdir.rb
+++ b/Formula/fdbdir.rb
@@ -30,6 +30,7 @@ class Fdbdir < Formula
       end
     end
   end
+
   def install
 
 bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?

--- a/Formula/fdbdir.rb
+++ b/Formula/fdbdir.rb
@@ -32,8 +32,7 @@ class Fdbdir < Formula
   end
 
   def install
-
-    bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
+  bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
     bin.install "fdbdir" if OS.mac? && Hardware::CPU.intel?
 
     # Ensure dyld can locate libfdb_c on macOS

--- a/Formula/fdbdir.rb
+++ b/Formula/fdbdir.rb
@@ -32,23 +32,14 @@ class Fdbdir < Formula
   end
 
   def install
+    bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
+    bin.install "fdbdir" if OS.mac? && Hardware::CPU.intel?
 
-      bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
-
-        bin.install "fdbdir" if OS.mac? && Hardware::CPU.intel?
-
-
-        # Ensure dyld can locate libfdb_c on macOS
-
-        if OS.mac?
-
-          macho = MachO::MachOFile.new((bin/["fdbdir"]).to_s)
-
-          macho.rpaths << "/usr/local/lib" unless macho.rpaths.include?("/usr/local/lib")
-
-          macho.rpaths << "/opt/homebrew/lib" unless macho.rpaths.include?("/opt/homebrew/lib")
-
-          macho.write!
+    if OS.mac?
+      macho = MachO::MachOFile.new((bin/"fdbdir").to_s)
+      macho.rpaths << "/usr/local/lib" unless macho.rpaths.include?("/usr/local/lib")
+      macho.rpaths << "/opt/homebrew/lib" unless macho.rpaths.include?("/opt/homebrew/lib")
+      macho.write!
     end
 
     bin.install "fdbdir" if OS.linux? && Hardware::CPU.intel?


### PR DESCRIPTION
Move ruby-macho rpath edits to run after bin.install so bin/fdbdir exists. Fixes upgrade error: ArgumentError ... bin/fdbdir: no such file.