### PR TITLE
fdbdir: use MachO::Tools.add_rpath for rpaths

### DIFF
--- a/Formula/fdbdir.rb
+++ b/Formula/fdbdir.rb
@@ -34,11 +34,11 @@ class Fdbdir < Formula
   def install
     bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
     bin.install "fdbdir" if OS.mac? && Hardware::CPU.intel?
+
     if OS.mac?
       MachO::Tools.add_rpath((bin/"fdbdir").to_s, "/usr/local/lib")
       MachO::Tools.add_rpath((bin/"fdbdir").to_s, "/opt/homebrew/lib")
     end
-
 
     bin.install "fdbdir" if OS.linux? && Hardware::CPU.intel?
 

--- a/Formula/fdbdir.rb
+++ b/Formula/fdbdir.rb
@@ -34,13 +34,11 @@ class Fdbdir < Formula
   def install
     bin.install "fdbdir" if OS.mac? && Hardware::CPU.arm?
     bin.install "fdbdir" if OS.mac? && Hardware::CPU.intel?
-
     if OS.mac?
-      macho = MachO::MachOFile.new((bin/"fdbdir").to_s)
-      macho.rpaths << "/usr/local/lib" unless macho.rpaths.include?("/usr/local/lib")
-      macho.rpaths << "/opt/homebrew/lib" unless macho.rpaths.include?("/opt/homebrew/lib")
-      macho.write!
+      MachO::Tools.add_rpath((bin/"fdbdir").to_s, "/usr/local/lib")
+      MachO::Tools.add_rpath((bin/"fdbdir").to_s, "/opt/homebrew/lib")
     end
+
 
     bin.install "fdbdir" if OS.linux? && Hardware::CPU.intel?
 


### PR DESCRIPTION
Switch from manual MachO::MachOFile edits to MachO::Tools.add_rpath to ensure LC_RPATH is written. Should address macOS runtime error: no LC_RPATH's found.