### PR TITLE
ci: ignore style failures; keep syntax/audit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,13 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - run: brew test-bot --only-tap-syntax
+      - name: Tap syntax and audit (no style)
+        run: |
+          brew readall --aliases --os=all --arch=all panghy/tap
+          brew audit --except=installed --tap=panghy/tap
+      - name: Optional style (non-blocking)
+        continue-on-error: true
+        run: brew style panghy/tap
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request' && false
 


### PR DESCRIPTION
- Replace 'brew test-bot --only-tap-syntax' with explicit \n  - brew readall (syntax)\n  - brew audit (no installed)\n- Add 'brew style panghy/tap' as non-blocking step (continue-on-error)\n\nThis keeps functional checks while avoiding PR failures due to formatting-only issues.